### PR TITLE
chore: resolve open dependabot security alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5372,13 +5372,13 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.0.tgz",
-      "integrity": "sha512-gDK8yiqKxrGta+3WtON59arrrw6GLmadA1qoFgYXzdcch8fmKDID2XqO8itsi3f1wufXYPT51387dN6cvVBS3Q==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz",
+      "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -5405,9 +5405,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5769,9 +5769,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.14",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
-      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+      "version": "4.12.18",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
+      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6018,9 +6018,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,10 @@
     "format": "prettier --write ."
   },
   "private": true,
+  "overrides": {
+    "hono": ">=4.12.16",
+    "ip-address": ">=10.1.1"
+  },
   "dependencies": {
     "@angular/animations": "^21.2.0",
     "@angular/common": "^21.2.0",

--- a/package.json
+++ b/package.json
@@ -10,10 +10,6 @@
     "format": "prettier --write ."
   },
   "private": true,
-  "overrides": {
-    "hono": ">=4.12.16",
-    "ip-address": ">=10.1.1"
-  },
   "dependencies": {
     "@angular/animations": "^21.2.0",
     "@angular/common": "^21.2.0",


### PR DESCRIPTION
## Summary

Resolved 7 open Dependabot security alerts by updating the `package-lock.json` lockfile. No overrides were needed — natural semver resolution picks up the patched versions.

## Dependabot Alerts Resolved

| Alert | Package | Severity | Fix |
|-------|---------|----------|-----|
| #96 | `hono` | **medium** | Lockfile updated to 4.12.18 (CSS Declaration Injection) |
| #95 | `hono` | **low** | Lockfile updated to 4.12.18 (improper JWT NumericDate validation) |
| #94 | `hono` | **medium** | Lockfile updated to 4.12.18 (Cache Middleware Vary header leakage) |
| #93 | `fast-uri` | **high** | Lockfile updated to 3.1.2 (host confusion via percent-encoded delimiters) |
| #92 | `fast-uri` | **high** | Lockfile updated to 3.1.2 (path traversal via percent-encoded dot segments) |
| #91 | `hono` | **medium** | Lockfile updated to 4.12.18 (Unvalidated JSX Tag Names / HTML injection) |
| #89 | `ip-address` | **medium** | Bumped `express-rate-limit` to 8.5.1, which pulls in `ip-address` 10.2.0 (XSS in Address6) |